### PR TITLE
ISO-8601 formatted dates; update example call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This script converts the data in that file to JSON format, for ease of browsing.
 
 Python 3.7.3
 
-`python clippings.py [<input filename> <output filename>]`
+`python clippings.py [-i <input filename> -o <output filename>]`
 
 If you do not supply \<input filename\>, the script defaults to "in/My Clippings.txt" which assumes you have a directory called "in" inside the directory where you put clippings.py.
 
@@ -27,7 +27,7 @@ Output file is in the format:
         "<title>" {
             "<location/page>" : [
                 {
-                    "date": "YYYYMMDD-HHMM",
+                    "date": "YYYY-MM-DDTHH:MM",
                     "quote": "<quote text>"
                 }
             ]

--- a/clippings.py
+++ b/clippings.py
@@ -438,7 +438,7 @@ def build_dict_line(line):
         author:{
             line[0]:{ # title
                 loc:[
-                    {"quote":quote,"date":date.strftime("%Y%m%d-%H%M")}
+                    {"quote":quote,"date":date.strftime("%Y-%m-%dT%H:%M")}
                 ]
             }
         }


### PR DESCRIPTION
I've changed the output date format to be ISO-8601 compatible, so that other tools can read the date more readily.

It might be nice to have a further option to include the timezone offset, so that the date is less ambiguous. The source `My Clippings.txt` does *not* include a timezone, but the user's system time zone could be used, configurable by changing the `TZ` environment variable.